### PR TITLE
READMEを整備

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,3 @@
+DB_NAME=使用するDBの名前
+DB_USER=MySQLのユーザ名
+DB_PASS=MySQLのパスワード

--- a/.gitignore
+++ b/.gitignore
@@ -31,3 +31,5 @@ build/
 
 ### VS Code ###
 .vscode/
+
+.env

--- a/README.md
+++ b/README.md
@@ -1,0 +1,28 @@
+# 概要
+- アプリ名は習慣ToDoリスト
+- 日々習慣付けをしたいタスクを管理するためのWebアプリ
+
+# ドキュメントの場所
+https://drive.google.com/drive/folders/1QjzJ9VN7L_G_fvTh885Sfn-unPxVzsaf
+
+# 事前にインストールが必要なソフト
+- Java 24
+- MySQL 8.0以上
+- VSCode拡張機能[Spring Boot Extension Pack](https://marketplace.visualstudio.com/items?itemName=vmware.vscode-boot-dev-pack)拡張機能をインストールする
+
+# ローカルでの環境構築手順
+1. MySQLに新しくDBを作成する
+    - `mysql -uroot -p`
+    - `create database <DB名>;`
+1. リポジトリのルートディレクトリにある.env.exampleファイルを複製して.envファイルを作る
+    - ファイルの中身の各行の右辺は各自のローカル環境に合わせて変更する
+
+# ローカルでの実行手順
+1. MySQLを起動する
+2. VSCodeの左のタブから「Spring Boot」タブを開く
+3. 「todoapp」の行の三角ボタンを押す
+    - ターミナルが開く
+4. ターミナルに「Started TodoappApplication」と表示されるまで待つ
+    - このとき、エンティティの定義に沿って接続先のDB内に自動でテーブルが作成される
+5. ブラウザで`http://localhost:8080`にアクセスする
+    - ログイン画面が表示される

--- a/README.md
+++ b/README.md
@@ -14,8 +14,9 @@ https://drive.google.com/drive/folders/1QjzJ9VN7L_G_fvTh885Sfn-unPxVzsaf
 1. MySQLに新しくDBを作成する
     - `mysql -uroot -p`
     - `create database <DB名>;`
-1. リポジトリのルートディレクトリにある.env.exampleファイルを複製して.envファイルを作る
-    - ファイルの中身の各行の右辺は各自のローカル環境に合わせて変更する
+1. リポジトリのルートディレクトリにある.env.exampleファイルを複製して同じ階層に.envファイルを作る
+    - リポジトリのルートディレクトリに.env.exampleファイルと.envファイルが並べばOK
+1. .envファイルの中身の各行の右辺は各自のローカル環境に合わせて変更する
 
 # ローカルでの実行手順
 1. MySQLを起動する

--- a/src/main/resources/application.properties
+++ b/src/main/resources/application.properties
@@ -1,9 +1,9 @@
 spring.application.name=todoapp
 
 # MySQL設定
-spring.datasource.url=jdbc:mysql://localhost:3306/todoapp_db?useSSL=false&serverTimezone=UTC
-spring.datasource.username=root
-spring.datasource.password=House7goose7
+spring.datasource.url=jdbc:mysql://localhost:3306/${DB_NAME}?useSSL=false&serverTimezone=UTC
+spring.datasource.username=${DB_USER}
+spring.datasource.password=${DB_PASS}
 
 # JPA設定
 spring.jpa.hibernate.ddl-auto=update


### PR DESCRIPTION
# やったこと
- DBの接続情報をgit管理外としました
  - 開発するPC毎に異なるためです
  - .envファイルに記載することで、アプリ起動時に自動で読み込まれ、application.propertyに埋め込まれます
- READMEを整備しました
  - 初めてこのリポジトリを触る人が最低限この情報があれば開発を始められるだろうって情報を書きました
  - このリポジトリのホーム画面で以下のように表示されます
![image](https://github.com/user-attachments/assets/1b4de64e-04d6-44b9-a88c-24674047e393)


# やっていないこと、妥協したこと、その他伝達事項
- READMEにこのくらいの情報を書くのは結構大事なので、今後はリポジトリ立ち上げ時に作りましょう
  - これが無いと数ヶ月後に追加開発するってなったときや別PCで開発するときに環境構築に手間取ります

# テスト手順
READMEの情報通りにローカル環境を設定してブラウザでログイン画面の表示までできること