### PR TITLE
削除機能フロント部分実装。それに伴うバックエンド側の一部修正

### DIFF
--- a/api-test.http
+++ b/api-test.http
@@ -1,18 +1,17 @@
 # ### タスクを追加
-# POST http://localhost:8080/api/tasks
-# Content-Type: application/json
+POST http://localhost:8080/tasks
+Content-Type: application/json  
 
-# {
-#     ""
-#     "title": "updateTask test",
-#     "dueDate": "2025-06-01T23:59:00",   
-#     "user": {
-#         "userId": 1
-#     }
-# }
+{
+    "title": "deleteTask test",
+    "dueDate": "2025-06-01T23:59:00",
+    "user": {
+        "userId": 1
+    }
+}
 
 ### タスク取得
-GET http://localhost:8080/tasks/1
+GET http://localhost:8080/tasks/6
 
 
 ### タスク更新（title変更 → createdAtも更新されることを確認）
@@ -40,3 +39,8 @@ Content-Type: application/json
     "userId": 1
   }
 }
+
+### タスクの削除
+
+DELETE http://localhost:8080/tasks/6
+Content-Type: application/json

--- a/src/main/java/com/example/todoapp/controller/TaskController.java
+++ b/src/main/java/com/example/todoapp/controller/TaskController.java
@@ -62,7 +62,7 @@ public class TaskController {
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    @PostMapping("/{id}")
+    @DeleteMapping("/{id}")
     public ResponseEntity<Void> deleteTask(@PathVariable Long id) {
         taskService.deleteTask(id);
         return ResponseEntity.noContent().build();

--- a/src/main/java/com/example/todoapp/controller/TaskController.java
+++ b/src/main/java/com/example/todoapp/controller/TaskController.java
@@ -48,29 +48,30 @@ public class TaskController {
         return "task_list";
     }
 
-    @GetMapping("/{id}")
-    public ResponseEntity<Task> getTaskById(@PathVariable Long id) {
-        Optional<Task> taskOpt = taskService.getTaskById(id);
+    @GetMapping("/{taskId}")
+    public ResponseEntity<Task> getTaskById(@PathVariable Long taskId) {
+        Optional<Task> taskOpt = taskService.getTaskById(taskId);
         return taskOpt.map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    @PutMapping("/{id}")
-    public ResponseEntity<Task> updateTask(@PathVariable Long id, @RequestBody Task updatedTask) {
-        return taskService.updateTask(id, updatedTask)
+    @PutMapping("/{taskId}")
+    public ResponseEntity<Task> updateTask(@PathVariable Long taskId, @RequestBody Task updatedTask) {
+        return taskService.updateTask(taskId, updatedTask)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    @DeleteMapping("/{id}")
-    public ResponseEntity<Void> deleteTask(@PathVariable Long id) {
-        taskService.deleteTask(id);
+    @PostMapping("/{taskId}")
+    public ResponseEntity<Void> deleteTask(@PathVariable Long taskId) {
+        taskService.deleteTask(taskId);
         return ResponseEntity.noContent().build();
     }
 
-    @PutMapping("/{id}/toggle")
-    public ResponseEntity<Void> toggleTaskCompletion(@PathVariable Long id) {
-        taskService.toggleTaskCompletion(id);
+
+    @PutMapping("/{taskId}/toggle")
+    public ResponseEntity<Void> toggleTaskCompletion(@PathVariable Long taskId) {
+        taskService.toggleTaskCompletion(taskId);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/java/com/example/todoapp/controller/TaskController.java
+++ b/src/main/java/com/example/todoapp/controller/TaskController.java
@@ -48,30 +48,30 @@ public class TaskController {
         return "task_list";
     }
 
-    @GetMapping("/{taskId}")
-    public ResponseEntity<Task> getTaskById(@PathVariable Long taskId) {
-        Optional<Task> taskOpt = taskService.getTaskById(taskId);
+    @GetMapping("/{id}")
+    public ResponseEntity<Task> getTaskById(@PathVariable Long id) {
+        Optional<Task> taskOpt = taskService.getTaskById(id);
         return taskOpt.map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    @PutMapping("/{taskId}")
+    @PutMapping("/{id}")
     public ResponseEntity<Task> updateTask(@PathVariable Long taskId, @RequestBody Task updatedTask) {
         return taskService.updateTask(taskId, updatedTask)
                 .map(ResponseEntity::ok)
                 .orElseGet(() -> ResponseEntity.notFound().build());
     }
 
-    @PostMapping("/{taskId}")
-    public ResponseEntity<Void> deleteTask(@PathVariable Long taskId) {
-        taskService.deleteTask(taskId);
+    @PostMapping("/{id}")
+    public ResponseEntity<Void> deleteTask(@PathVariable Long id) {
+        taskService.deleteTask(id);
         return ResponseEntity.noContent().build();
     }
 
 
-    @PutMapping("/{taskId}/toggle")
-    public ResponseEntity<Void> toggleTaskCompletion(@PathVariable Long taskId) {
-        taskService.toggleTaskCompletion(taskId);
+    @PutMapping("/{id}/toggle")
+    public ResponseEntity<Void> toggleTaskCompletion(@PathVariable Long id) {
+        taskService.toggleTaskCompletion(id);
         return ResponseEntity.ok().build();
     }
 

--- a/src/main/resources/static/js/deleteTask.js
+++ b/src/main/resources/static/js/deleteTask.js
@@ -1,8 +1,10 @@
-function deleteTask(taskId) {
+function deleteTask(taskId, event) {
+    if (event) event.preventDefault(); // ← これを追加
+
     if (!confirm("この目標を削除しますか？")) return;
 
     fetch(`/tasks/${taskId}`, { 
-        method: 'POST',
+        method: 'DELETE',
         headers: {
             'Content-Type': 'application/json'
         }
@@ -12,9 +14,7 @@ function deleteTask(taskId) {
             throw new Error("削除に失敗しました。");
         }
         console.log("削除成功、画面リロード...");
-        
-        // 画面を再読み込みする
-        location.reload();  // ✅←これでページ全体をリロード
+        location.reload();
     })
     .catch(error => {
         console.error("エラー:", error);

--- a/src/main/resources/static/js/deleteTask.js
+++ b/src/main/resources/static/js/deleteTask.js
@@ -1,0 +1,27 @@
+function deleteTask(taskId) {
+    if (!confirm("本当に削除しますか？")) return;
+
+    fetch(`/tasks/${taskId}`, { 
+        method: 'POST',  // ここはPOSTのままで進める
+        headers: {
+            'Authorization': `Bearer ${token}`,
+            'Content-Type': 'application/json'
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error("削除に失敗しました。");
+        }
+        console.log("削除成功、画面更新...");
+
+        // **削除したタスクをDOMから削除**
+        const taskElement = document.getElementById(`task-${taskId}`);
+        if (taskElement) {
+            taskElement.remove();  // 画面上のタスク要素を削除
+        }
+    })
+    .catch(error => {
+        console.error("エラー:", error);
+        alert(error.message);
+    });
+}

--- a/src/main/resources/static/js/deleteTask.js
+++ b/src/main/resources/static/js/deleteTask.js
@@ -1,10 +1,10 @@
 function deleteTask(taskId) {
-    if (!confirm("本当に削除しますか？")) return;
+    if (!confirm("この目標を削除しますか？")) return;
 
     fetch(`/tasks/${taskId}`, { 
-        method: 'POST',  // ここはPOSTのままで進める
+        method: 'POST',  // 削除はPOSTで進める
         headers: {
-            'Authorization': `Bearer ${token}`,
+            'Authorization': `Bearer ${jwtToken}`,
             'Content-Type': 'application/json'
         }
     })

--- a/src/main/resources/static/js/deleteTask.js
+++ b/src/main/resources/static/js/deleteTask.js
@@ -2,9 +2,8 @@ function deleteTask(taskId) {
     if (!confirm("この目標を削除しますか？")) return;
 
     fetch(`/tasks/${taskId}`, { 
-        method: 'POST',  // 削除はPOSTで進める
+        method: 'POST',
         headers: {
-            'Authorization': `Bearer ${jwtToken}`,
             'Content-Type': 'application/json'
         }
     })
@@ -12,13 +11,10 @@ function deleteTask(taskId) {
         if (!response.ok) {
             throw new Error("削除に失敗しました。");
         }
-        console.log("削除成功、画面更新...");
-
-        // **削除したタスクをDOMから削除**
-        const taskElement = document.getElementById(`task-${taskId}`);
-        if (taskElement) {
-            taskElement.remove();  // 画面上のタスク要素を削除
-        }
+        console.log("削除成功、画面リロード...");
+        
+        // 画面を再読み込みする
+        location.reload();  // ✅←これでページ全体をリロード
     })
     .catch(error => {
         console.error("エラー:", error);

--- a/src/main/resources/templates/task_list.html
+++ b/src/main/resources/templates/task_list.html
@@ -113,7 +113,7 @@
                     <td class="display-mode action-buttons">
                         <button class="edit-button">編集</button>
                         <form th:action="@{/tasks/{taskId}(taskId=${task.taskId})}" method="post" onsubmit="return confirm('この目標を削除しますか？');">
-                            <button type="submit" class="delete-button">削除</button>
+                            <button th:onclick="'deleteTask(' + ${task.taskId} + ')'" class="delete-button">削除</button>
                         </form>
                     </form>
                     </td>

--- a/src/main/resources/templates/task_list.html
+++ b/src/main/resources/templates/task_list.html
@@ -5,6 +5,7 @@
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <link rel="stylesheet" th:href="@{css/style.css}">
         <script th:src="@{/js/edit-task.js}"></script>
+        <script th:src="@{/js/deleteTask.js}"></script>
     </head>
     <body>
         <div class="header-container">

--- a/src/main/resources/templates/task_list.html
+++ b/src/main/resources/templates/task_list.html
@@ -3,7 +3,7 @@
     <head>
         <title>習慣ToDoリスト</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
-        <link rel="stylesheet" href="style.css">
+        <link rel="stylesheet" th:href="@{css/style.css}">
 
         <script th:inline="javascript">
             window.onload = function() {

--- a/src/main/resources/templates/task_list.html
+++ b/src/main/resources/templates/task_list.html
@@ -7,7 +7,7 @@
         <script th:src="@{/js/task_create.js}"defer></script>
         <script th:src="@{/js/edit-task.js}"defer></script>
         <script th:src="@{/js/logout.js}"defer></script>
-        <script th:src="@{/js/delete-task.js}"defer></script>
+        <script th:src="@{/js/deleteTask.js}"defer></script>
     </head>
     <body>
         <div class="header-container">

--- a/src/main/resources/templates/task_list.html
+++ b/src/main/resources/templates/task_list.html
@@ -105,24 +105,25 @@
                         <span th:text="${task.title}" th:class="${#lists.contains(completedTaskIds, task.taskId)} ? 'completed' : ''" data-task-title></span>
                     </td>
                     <td class="display-mode">
-                        <span th:if="${task.dueDate}" th:text="${#temporals.format(task.dueDate, 'HH:mm')}"></span>
+                        <span th:text="${task.dueDate} ?: '未設定'">2025-05-24</span>
                         <span th:unless="${task.dueDate}" class="no-due-date"> ー </span>
                     </td>
                     <td class="display-mode"><span th:text="${#temporals.format(task.createdAt, 'yyyy/MM/dd')}"></span></td>
-                    <td class="display-mode"><span th:text="${task.streakCount != null ? task.streakCount + '日' : '0日'}"></span></td>
+                    <td class="display-mode"><span th:text="${task.currentStreak != null ? task.currentStreak + '日' : '0日'}"></span></td>
                     <td class="display-mode action-buttons">
                         <button class="edit-button">編集</button>
-                        <form th:action="@{/tasks/{taskId}/delete(taskId=${task.taskId})}" method="post" onsubmit="return confirm('この目標を削除しますか？');">
+                        <form th:action="@{/tasks/{taskId}(taskId=${task.taskId})}" method="post" onsubmit="return confirm('この目標を削除しますか？');">
                             <button type="submit" class="delete-button">削除</button>
                         </form>
+                    </form>
                     </td>
 
                     <td class="edit-mode" colspan="5">
                         <form th:action="@{/tasks/{taskId}/update(taskId=${task.taskId})}" method="post">
                             <input type="text" name="title" th:value="${task.title}" placeholder="目標名を入力してください" class="edit-title-input">
-                            <input type="time" name="dueDate" th:value="${task.dueDate ? #temporals.format(task.dueDate, 'HH:mm') : ''}" placeholder="予定時刻" class="edit-duedate-input">
+                            <input type="time" name="dueDate" th:value="${task.dueDate != null ? #temporals.format(task.dueDate, 'HH:mm') : ''}" placeholder="予定時刻" class="edit-duedate-input">
                             <span>設定日: <span th:text="${#temporals.format(task.createdAt, 'yyyy/MM/dd')}"></span></span>
-                            <span>連続日数: <span th:text="${task.streakCount != null ? task.streakCount + '日' : '0日'}"></span></span>
+                            <span>連続日数: <span th:text="${task.currentStreak != null ? task.currentStreak + '日' : '0日'}"></span></span>
                             <button type="submit" class="edit-ok-button">OK</button>
                             <button type="button" class="edit-cancel-button">キャンセル</button>
                         </form>

--- a/src/main/resources/templates/task_list.html
+++ b/src/main/resources/templates/task_list.html
@@ -4,7 +4,7 @@
         <title>習慣ToDoリスト</title>
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <link rel="stylesheet" th:href="@{css/style.css}">
-
+        <script th:src="@{js/deleteTask.js}"></script>
         <script th:inline="javascript">
             window.onload = function() {
                 function validateTaskTitles() {
@@ -112,7 +112,7 @@
                     <td class="display-mode"><span th:text="${task.currentStreak != null ? task.currentStreak + '日' : '0日'}"></span></td>
                     <td class="display-mode action-buttons">
                         <button class="edit-button">編集</button>
-                        <form th:action="@{/tasks/{taskId}(taskId=${task.taskId})}" method="post" onsubmit="return confirm('この目標を削除しますか？');">
+                        <form th:action="@{/tasks/{taskId}(taskId=${task.taskId})}" method="post" >
                             <button th:onclick="'deleteTask(' + ${task.taskId} + ')'" class="delete-button">削除</button>
                         </form>
                     </form>

--- a/src/main/resources/templates/task_list.html
+++ b/src/main/resources/templates/task_list.html
@@ -112,12 +112,10 @@
                     <td class="display-mode"><span th:text="${task.currentStreak != null ? task.currentStreak + '日' : '0日'}"></span></td>
                     <td class="display-mode action-buttons">
                         <button class="edit-button">編集</button>
-                        <form th:action="@{/tasks/{taskId}(taskId=${task.taskId})}" method="post" >
-                            <button th:onclick="'deleteTask(' + ${task.taskId} + ')'" class="delete-button">削除</button>
-                        </form>
-                    </form>
+                        <button type="button" th:onclick="|deleteTask(${task.taskId}, event)|" class="delete-button">
+                            削除
+                        </button>
                     </td>
-
                     <td class="edit-mode" colspan="5">
                         <form th:action="@{/tasks/{taskId}/update(taskId=${task.taskId})}" method="post">
                             <input type="text" name="title" th:value="${task.title}" placeholder="目標名を入力してください" class="edit-title-input">


### PR DESCRIPTION
# やったこと
削除機能フロント部分実装（JSとHTMLの修正）。それに伴うバックエンド側の一部修正（Contollerの修正）。

# やっていないこと、妥協したこと、その他伝達事項
画面を再読み込みしないと表示上では消えないままです。

# テスト手順
api-tesu.httpでタスクを追加→localhost:8080/tasksで削除ボタンを実行