### PR TITLE
目標完了機能

### DIFF
--- a/api-test.http
+++ b/api-test.http
@@ -39,3 +39,11 @@ Content-Type: application/json
     "userId": 1
   }
 }
+
+### タスク完了状態の切り替え
+PUT http://localhost:8080/tasks/1/toggle
+Content-Type: application/
+
+### ユーザーのタスクステータスを更新
+POST http://localhost:8080/tasks/user/1/updateStreak
+Content-Type: application/json

--- a/src/main/java/com/example/todoapp/controller/TaskController.java
+++ b/src/main/java/com/example/todoapp/controller/TaskController.java
@@ -12,6 +12,7 @@ import com.example.todoapp.domain.Task;
 import com.example.todoapp.domain.User;
 import com.example.todoapp.repository.UserRepository;
 import com.example.todoapp.service.TaskService;
+import com.example.todoapp.service.UserService;
 
 import lombok.RequiredArgsConstructor;
 
@@ -22,6 +23,7 @@ public class TaskController {
 
     private final TaskService taskService;
     private final UserRepository userRepository;
+    private final UserService userService;
 
     @PostMapping
     public ResponseEntity<Task> createTask(@RequestBody Task task) {
@@ -74,5 +76,12 @@ public class TaskController {
         taskService.toggleTaskCompletion(id);
         return ResponseEntity.ok().build();
     }
+
+    @PostMapping("/user/{userId}/updateStreak")
+    public ResponseEntity<Void> updateUserTasks(@PathVariable Long userId) {
+        taskService.whenDateChange(userId);
+        return ResponseEntity.ok().build();
+    }
+
 
 }

--- a/src/main/resources/static/js/toggle-task.js
+++ b/src/main/resources/static/js/toggle-task.js
@@ -1,0 +1,18 @@
+function toggleTaskCompletion(taskId) {
+    fetch(`/tasks/${taskId}/toggle`, {
+        method: 'PUT',
+        headers: {
+            'Content-Type': 'application/json'
+        }
+    })
+    .then(response => {
+        if (!response.ok) {
+            throw new Error('完了状態の切り替えに失敗しました。');
+        }
+        location.reload();
+    })
+    .catch(error => {
+        console.error('エラー:', error);
+        alert(error.message);
+    });
+}

--- a/src/main/resources/templates/task_list.html
+++ b/src/main/resources/templates/task_list.html
@@ -5,6 +5,7 @@
         <meta http-equiv="Content-Type" content="text/html; charset=UTF-8" />
         <link rel="stylesheet" th:href="@{css/style.css}">
         <script th:src="@{/js/edit-task.js}"></script>
+        <script th:src="@{/js/taskToggle.js}"></script>
     </head>
     <body>
         <div class="header-container">
@@ -18,6 +19,7 @@
         <table th:class="${allTasksCompleted ? 'all-completed' : ''}">
             <thead>
                 <tr>
+                    <th>完了</th>
                     <th>目標名</th>
                     <th>予定時刻</th>
                     <th>連続日数</th>
@@ -28,9 +30,11 @@
             <tbody>
                 <tr th:each="task : ${tasks}" class="task-item" th:attr="data-task-id=${task.taskId}">
                     <td class="display-mode">
-                        <form th:action="@{/tasks/{taskId}/toggle(taskId=${task.taskId})}" method="post">
-                            <input type="checkbox" name="completed" th:checked="${#lists.contains(completedTaskIds, task.taskId)}">
-                        </form>
+                        <input type="checkbox"
+                            th:checked="${task.completed}"
+                            th:onchange="|toggleTaskCompletion(${task.taskId})|">
+                    </td>
+                    <td class="display-mode">
                         <span th:text="${task.title}" th:class="${#lists.contains(completedTaskIds, task.taskId)} ? 'completed' : ''" data-task-title></span>
                     </td>
                     <td class="display-mode">
@@ -46,7 +50,7 @@
                         </form>
                     </td>
 
-                    <td class="edit-mode" colspan="5">
+                    <td class="edit-mode" colspan="6">
                     <form th:action="@{/tasks/{id}(id=${task.taskId})}" method="post">
                         <input type="text" name="title" th:value="${task.title}" placeholder="目標名を入力してください" class="edit-title-input">
 
@@ -64,7 +68,7 @@
                 </tr>
 
                 <tr id="newRow" class="new-row hidden">
-                    <td colspan="5">
+                    <td colspan="6">
                         <form th:action="@{/tasks/create}" method="post">
                             <input type="text" name="title" placeholder="目標名を入力してください" class="new-task-title-input">
                             <input type="time" name="dueDate" placeholder="予定時刻" class="new-task-duedate-input">


### PR DESCRIPTION
# やったこと
目標の完了機能のチェックボックスの作成。
目標が日が変わるとリセットされる仕組みの見直し

# やっていないこと、妥協したこと、その他伝達事項


# テスト手順
api-test.httpでタスクの完了状態切り替えととユーザーのタスクステータスを更新を使う。
localhost:8080/tasksで動作確認